### PR TITLE
Replace from sklearn.externals.six import StringIO

### DIFF
--- a/Play Tennis  Implementation Using Sklearn Decision Tree Algorithm.ipynb
+++ b/Play Tennis  Implementation Using Sklearn Decision Tree Algorithm.ipynb
@@ -1000,7 +1000,7 @@
    ],
    "source": [
     "from sklearn.tree import export_graphviz\n",
-    "from sklearn.externals.six import StringIO\n",
+    "from io import StringIO  # Replace from sklearn.externals.six import StringIO | This module was deprecated and removed from scikit-learn in version 1.2.\n",
     "from IPython.display import Image\n",
     "import pydotplus\n",
     "dot_data = StringIO()\n",


### PR DESCRIPTION
This module was deprecated and removed from scikit-learn in version 1.2.